### PR TITLE
Setup react-native-dotenv and updated the project setup instructions on Readme

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "plugins": [
+      ["module:react-native-dotenv"]
+    ]
+  }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-    "plugins": [
-      ["module:react-native-dotenv"]
-    ]
-  }

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BACKEND_URL=https://api.staging.tides.coloredcow.com/api

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ web-build/
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
+
+*.env

--- a/Readme.md
+++ b/Readme.md
@@ -7,12 +7,42 @@
 * Android SDK
 * Yarn >=@v1.22.19
 
-### Installation steps
-- Run ``git clone https://github.com/glific/mobile.git`` 
-- Run ``cd mobile``
-- Run ``yarn install``
-- Run ``yarn start``
-- Run ``npx expo install react-native`` (Incase if react-native version is not updated)
+### Setup
+
+The following setup helps you to run the application on an android machine. Read the [documentation](https://reactnative.dev/docs/running-on-simulator-ios) of react-native to know about running it on iOS devices.
+
+1) Clone the repository
+```sh
+git clone git@github.com:glific/mobile.git
+```
+You can also use https to clone the repository. To know more read this [documentation](https://docs.gitlab.com/ee/gitlab-basics/start-using-git.html#clone-with-https).
+
+2) Now change the directory by navigating into the cloned repository. Use the following command, in case of linux.
+```sh
+cd mobile
+```
+
+3) Create an environment file in the project's home directory with the filename `.env` and add the following key-value pairs.
+```
+BACKEND_URL=
+```
+
+You can access these variables in any component using the following:
+```js
+import { BACKEND_URL } from "@env";
+```
+
+4) Install the dependencies using yarn.
+```sh
+yarn install
+```
+
+5) Start the metro server.
+```sh
+yarn start
+```
+
+Note that you need to connect either an android device or an emulator with your PC to run the application.
 
 ### Testing (Android phone)
 

--- a/Readme.md
+++ b/Readme.md
@@ -22,22 +22,14 @@ You can also use https to clone the repository. To know more read this [document
 cd mobile
 ```
 
-3) Create an environment file in the project's home directory with the filename `.env` and add the following key-value pairs.
-```
-BACKEND_URL=
-```
+1) Create an environment file in the project's home directory with the filename `.env`, copy the contents from `.env.example` and update the key-value pairs based on the current environment the application is running in.
 
-You can access these variables in any component using the following:
-```js
-import { BACKEND_URL } from "@env";
-```
-
-4) Install the dependencies using yarn.
+2) Install the dependencies using yarn.
 ```sh
 yarn install
 ```
 
-5) Start the metro server.
+1) Start the metro server.
 ```sh
 yarn start
 ```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/react": "~18.0.14",
+    "react-native-dotenv": "^3.4.8",
     "typescript": "^4.9.4"
   },
   "private": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,6 +2959,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -5596,6 +5601,13 @@ react-native-codegen@^0.71.5:
     flow-parser "^0.185.0"
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
+
+react-native-dotenv@^3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/react-native-dotenv/-/react-native-dotenv-3.4.8.tgz#42284070a9994076cd700805c2dd28051c9e1432"
+  integrity sha512-fg9F8X/cG1kDTwRLgLz3t+AMbsULoFHbUVltdQarmrJ3kNllD1Zq7ZgY85bp8BnPwk0DnYQzKbooiLsUoKd10w==
+  dependencies:
+    dotenv "^16.0.3"
 
 react-native-gradle-plugin@^0.71.15:
   version "0.71.15"


### PR DESCRIPTION
## Description
This pull request uses [react-native-dotenv](https://github.com/goatandsheep/react-native-dotenv) to inject the environment variables into the Javascript environment.

## Changes Made
- Added [react-native-dotenv](https://github.com/goatandsheep/react-native-dotenv) package
- Created a `.babelrc` file and configured the plugin
- Updated the readme to include the `.env` setup and usage

## Related Issues
- fixes #4 