### PR TITLE
Add tabs for contacts collection & saved searches

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,14 +1,14 @@
 import 'react-native-gesture-handler';
-import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, SafeAreaView, StatusBar } from "react-native";
 import Navigation from "./navigations";
+import { Colors } from './constants/styles';
 
 export default function App() {
   return (
-    <>
-      <StatusBar style="light" />
+    <SafeAreaView style={{ flex: 1 }}>
+      <StatusBar backgroundColor={Colors.primary400} />
       <Navigation />
-    </>
+    </SafeAreaView>
   );
 }
 

--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@ import { Colors } from './constants/styles';
 
 export default function App() {
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={styles.container}>
       <StatusBar backgroundColor={Colors.primary400} />
       <Navigation />
     </SafeAreaView>
@@ -14,6 +14,6 @@ export default function App() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flex: 1
   },
 });

--- a/__tests__/Collections.test.tsx
+++ b/__tests__/Collections.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import Collections from '../screens/Collections';
+
+describe('Collections Screen', () => {
+  test('renders the Collections screen', () => {
+    const { getByText } = render(<Collections />);
+    const collectionsText = getByText('Collections');
+    expect(collectionsText).toBeDefined();
+  });
+});

--- a/__tests__/SavedSearchs.test.tsx
+++ b/__tests__/SavedSearchs.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import SavedSearches from '../screens/SavedSearches';
+
+describe('SavedSearches Screen', () => {
+  test('renders the SavedSearches screen', () => {
+    const { getByText } = render(<SavedSearches />);
+    const savedSearchesText = getByText('SavedSearches');
+    expect(savedSearchesText).toBeDefined();
+  });
+});

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text } from 'react-native';
 
 import { Colors } from '../../constants/styles';
 

--- a/components/ui/SearchBar.tsx
+++ b/components/ui/SearchBar.tsx
@@ -34,33 +34,35 @@ const SearchBar = () => {
   }
 
   return (
-    <View style={styles.inputContainer}>
-      <AntDesign
-        testID="search1"
-        name="search1"
-        size={20}
-        style={styles.icon}
-        onPress={onSearchHandler}
-      />
-      <TextInput
-        testID="Search Input"
-        style={styles.input}
-        autoCapitalize="none"
-        keyboardType="default"
-        placeholder="Search"
-        onChangeText={onSearch}
-        value={searchValue}
-        cursorColor={Colors.darkGray}
-        selectionColor={Colors.darkGray}
-        underlineColorAndroid="transparent"
-      />
-      <Ionicons
-        testID="filter-outline"
-        name="filter-outline"
-        size={20}
-        style={styles.icon}
-        onPress={onFilter}
-      />
+    <View style={styles.mainContainer}>
+      <View style={styles.inputContainer}>
+        <AntDesign
+          testID="search1"
+          name="search1"
+          size={20}
+          style={styles.icon}
+          onPress={onSearchHandler}
+        />
+        <TextInput
+          testID="Search Input"
+          style={styles.input}
+          autoCapitalize="none"
+          keyboardType="default"
+          placeholder="Search"
+          onChangeText={onSearch}
+          value={searchValue}
+          cursorColor={Colors.darkGray}
+          selectionColor={Colors.darkGray}
+          underlineColorAndroid="transparent"
+        />
+        <Ionicons
+          testID="filter-outline"
+          name="filter-outline"
+          size={20}
+          style={styles.icon}
+          onPress={onFilter}
+        />
+      </View>
     </View>
   );
 };
@@ -68,9 +70,15 @@ const SearchBar = () => {
 export default SearchBar;
 
 const styles = StyleSheet.create({
+  mainContainer: {
+    paddingVertical: 12,
+    backgroundColor: 'white',
+    borderTopWidth: 0.2,
+    borderBottomWidth: 0.2,
+    borderColor: Colors.darkGray
+  },
   inputContainer: {
     width: '95%',
-    marginVertical: 8,
     flexDirection: 'row',
     backgroundColor: 'white',
     alignSelf: 'center',

--- a/components/ui/SearchBar.tsx
+++ b/components/ui/SearchBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { View, TextInput, StyleSheet } from 'react-native';
 import { Colors } from '../../constants/styles';
 import { AntDesign, Ionicons } from '@expo/vector-icons';
 

--- a/constants/styles.ts
+++ b/constants/styles.ts
@@ -1,6 +1,7 @@
 export const Colors = {
   primary10: '#E2F2EB',
   primary50: '#E1E8E5',
+  primary70: '#6E8E7F',
   primary100: '#119656',
   primary400: '#073f24',
   secondary100: '#f9f7f4',

--- a/navigations/AppStack.js
+++ b/navigations/AppStack.js
@@ -9,12 +9,12 @@ const AppStack = () => {
   return (
     <Stack.Navigator
       screenOptions={{
-        headerStyle: { backgroundColor: Colors.primary400 },
-        headerTintColor: 'white',
+        headerShown: false,
         contentStyle: { backgroundColor: Colors.secondary100 },
       }}
     >
       <Stack.Screen name="Home" component={AppDrawer} />
+      <Stack.Screen name="Chat Page" component={ChatPage} />
     </Stack.Navigator>
   );
 };

--- a/navigations/AuthStack.js
+++ b/navigations/AuthStack.js
@@ -22,7 +22,7 @@ const AuthStack = () => {
         options={{ title: 'Add your organisation URL' }}
       />
       <Stack.Screen name="Login" component={Login} />
-      <Stack.Screen name="Chat" component={AppDrawer} />
+      <Stack.Screen name="Home" component={AppDrawer} options={{headerShown: false}}/>
     </Stack.Navigator>
   );
 };

--- a/navigations/Drawer.js
+++ b/navigations/Drawer.js
@@ -3,7 +3,6 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 import { Colors } from '../constants/styles';
 import { Entypo, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 
-import Chat from '../screens/Chat';
 import Notifications from '../screens/Notifications';
 import MyAccount from '../screens/MyAccount';
 import Setting from '../screens/Setting';

--- a/navigations/Drawer.js
+++ b/navigations/Drawer.js
@@ -9,6 +9,7 @@ import MyAccount from '../screens/MyAccount';
 import Setting from '../screens/Setting';
 import Help from '../screens/Help';
 import CustomDrawer from '../components/navigation/CustomDrawer';
+import HomeTabs from './HomeTabs';
 
 const Drawer = createDrawerNavigator();
 
@@ -17,18 +18,20 @@ const AppDrawer = () => {
     <Drawer.Navigator
       initialRouteName="Home"
       screenOptions={{
-        headerShown: false,
         drawerActiveBackgroundColor: Colors.primary400,
         drawerActiveTintColor: '#fff',
         drawerLabelStyle: {
           marginLeft: -15,
         },
+        headerStyle: { backgroundColor: Colors.primary400 },
+        headerTintColor: 'white',
+        contentStyle: { backgroundColor: Colors.secondary100 },
       }}
       drawerContent={(props) => <CustomDrawer {...props} />}
     >
       <Drawer.Screen
-        name="Home"
-        component={Chat}
+        name="Chat"
+        component={HomeTabs}
         options={{
           drawerIcon: ({ color }) => <Entypo name="chat" size={20} color={color} />,
         }}

--- a/navigations/HomeTabs.js
+++ b/navigations/HomeTabs.js
@@ -1,0 +1,29 @@
+import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import Chat from '../screens/Chat';
+import Collections from '../screens/Collections';
+import SavedSearches from '../screens/SavedSearches';
+import { Colors } from '../constants/styles';
+
+const Tab = createMaterialTopTabNavigator();
+
+const HomeTabs = () => {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        swipeEnabled: false,
+        tabBarStyle: { backgroundColor: Colors.primary10, elevation: 0, shadowOpacity: 0 },
+        tabBarLabelStyle: { fontSize: 12, fontWeight: 700 },
+        tabBarActiveTintColor: Colors.primary400,
+        tabBarInactiveTintColor: Colors.primary70,
+        tabBarIndicatorStyle: { backgroundColor: Colors.primary400 },
+        tabBarAndroidRipple: { borderless: true, color: Colors.primary70 }
+      }}
+    >
+      <Tab.Screen name="Contacts" component={Chat} />
+      <Tab.Screen name="Collections" component={Collections} />
+      <Tab.Screen name="SavedSearches" component={SavedSearches} options={{title: "Saved Searches"}}/>
+    </Tab.Navigator>
+  );
+}
+
+export default HomeTabs

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/axios": "^0.14.0",
     "axios": "^1.4.0",
     "expo": "~48.0.5",
-    "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-dotenv": "^3.4.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@expo/vector-icons": "^13.0.0",
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-navigation/drawer": "^6.6.2",
+    "@react-navigation/material-top-tabs": "^6.6.2",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "@types/axios": "^0.14.0",
@@ -23,9 +24,11 @@
     "react-native": "0.71.8",
     "react-native-dotenv": "^3.4.8",
     "react-native-gesture-handler": "~2.9.0",
+    "react-native-pager-view": "6.1.2",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.20.0"
+    "react-native-screens": "~3.20.0",
+    "react-native-tab-view": "^3.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/Chat.tsx
+++ b/screens/Chat.tsx
@@ -34,7 +34,7 @@ const Chat = ({ navigation }: Props) => {
   };
 
   return (
-    <View>
+    <View style={styles.mainContainer}>
       <SearchBar />
       <Text>Chat Screen</Text>
       <Button onPress={LogoutHandler}>
@@ -45,3 +45,9 @@ const Chat = ({ navigation }: Props) => {
 };
 
 export default Chat;
+
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+});

--- a/screens/Collections.tsx
+++ b/screens/Collections.tsx
@@ -1,0 +1,16 @@
+import { StyleSheet, Text, View } from 'react-native'
+import React from 'react'
+import SearchBar from '../components/ui/SearchBar'
+
+const Collections = () => {
+  return (
+    <View>
+        <SearchBar />
+        <Text>Collections</Text>
+    </View>
+  )
+}
+
+export default Collections
+
+const styles = StyleSheet.create({})

--- a/screens/Collections.tsx
+++ b/screens/Collections.tsx
@@ -4,7 +4,7 @@ import SearchBar from '../components/ui/SearchBar'
 
 const Collections = () => {
   return (
-    <View>
+    <View style={styles.mainContainer}>
         <SearchBar />
         <Text>Collections</Text>
     </View>
@@ -13,4 +13,8 @@ const Collections = () => {
 
 export default Collections
 
-const styles = StyleSheet.create({})
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+})

--- a/screens/Help.tsx
+++ b/screens/Help.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const Help = () => {
   return (
-    <View>
+    <View style={styles.mainContainer}>
       <Text>Help</Text>
     </View>
   );
@@ -11,4 +11,8 @@ const Help = () => {
 
 export default Help;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+});

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -45,7 +45,7 @@ const Login = ({ navigation }: Props) => {
       });
 
       await Storage.storeData('session', JSON.stringify(response.data.data));
-      navigation.navigate('Chat');
+      navigation.navigate('Home');
     } catch (error: any) {
       setErrorMessage(error.message);
     }

--- a/screens/MyAccount.tsx
+++ b/screens/MyAccount.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const MyAccount = () => {
   return (
-    <View>
+    <View style={styles.mainContainer}>
       <Text>MyAccount</Text>
     </View>
   );
@@ -11,4 +11,8 @@ const MyAccount = () => {
 
 export default MyAccount;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+});

--- a/screens/Notifications.tsx
+++ b/screens/Notifications.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const Notifications = () => {
   return (
-    <View>
+    <View style={styles.mainContainer}>
       <Text>Notifications</Text>
     </View>
   );
@@ -11,4 +11,8 @@ const Notifications = () => {
 
 export default Notifications;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+});

--- a/screens/SavedSearches.tsx
+++ b/screens/SavedSearches.tsx
@@ -4,7 +4,7 @@ import SearchBar from '../components/ui/SearchBar'
 
 const SavedSearches = () => {
   return (
-    <View>
+    <View style={styles.mainContainer}>
         <SearchBar />
         <Text>SavedSearches</Text>
     </View>
@@ -13,4 +13,8 @@ const SavedSearches = () => {
 
 export default SavedSearches
 
-const styles = StyleSheet.create({})
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+})

--- a/screens/SavedSearches.tsx
+++ b/screens/SavedSearches.tsx
@@ -1,0 +1,16 @@
+import { StyleSheet, Text, View } from 'react-native'
+import React from 'react'
+import SearchBar from '../components/ui/SearchBar'
+
+const SavedSearches = () => {
+  return (
+    <View>
+        <SearchBar />
+        <Text>SavedSearches</Text>
+    </View>
+  )
+}
+
+export default SavedSearches
+
+const styles = StyleSheet.create({})

--- a/screens/Setting.tsx
+++ b/screens/Setting.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const Setting = () => {
   return (
-    <View>
+    <View style={styles.mainContainer}>
       <Text>Setting</Text>
     </View>
   );
@@ -11,4 +11,8 @@ const Setting = () => {
 
 export default Setting;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,11 +3753,6 @@ expo-modules-core@1.2.7:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
 
-expo-status-bar@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.4.4.tgz#6874ccfda5a270d66f123a9f220735a76692d114"
-  integrity sha512-5DV0hIEWgatSC3UgQuAZBoQeaS9CqeWRZ3vzBR9R/+IUD87Adbi4FGhU10nymRqFXOizGsureButGZIXPs7zEA==
-
 expo@~48.0.5:
   version "48.0.16"
   resolved "https://registry.yarnpkg.com/expo/-/expo-48.0.16.tgz#afce3906eba8d0faa72f6e0e1c8aed4f1b046326"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,6 +1953,14 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.17.tgz#9cb95765940f2841916fc71686598c22a3e4067e"
   integrity sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==
 
+"@react-navigation/material-top-tabs@^6.6.2":
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-6.6.2.tgz#ff68e597451a86d26421d5f516a1aa7e1fb30048"
+  integrity sha512-qq0iyMzWApeSvhxovurhk5hluAH2VYbSObTZIKt4KbVXZ0KP8ir1tRQ+IAwkMea+hCnd26glpXRVQI+YqXH0Gw==
+  dependencies:
+    color "^4.2.3"
+    warn-once "^0.1.0"
+
 "@react-navigation/native-stack@^6.9.12":
   version "6.9.12"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-6.9.12.tgz#a09fe43ab2fc4c82a1809e3953021d1da4ead85c"
@@ -6751,6 +6759,11 @@ react-native-gradle-plugin@^0.71.18:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.18.tgz#20ef199bc85be32e45bb6cc069ec2e7dcb1a74a6"
   integrity sha512-7F6bD7B8Xsn3JllxcwHhFcsl9aHIig47+3eN4IHFNqfLhZr++3ElDrcqfMzugM+niWbaMi7bJ0kAkAL8eCpdWg==
 
+react-native-pager-view@6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.1.2.tgz#3522079b9a9d6634ca5e8d153bc0b4d660254552"
+  integrity sha512-qs2KSFc+7N7B+UZ6SG2sTvCkppagm5fVyRclv1KFKc7lDtrhXLzN59tXJw575LDP/dRJoXsNwqUAhZJdws6ABQ==
+
 react-native-reanimated@~2.14.4:
   version "2.14.4"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz#3fa3da4e7b99f5dfb28f86bcf24d9d1024d38836"
@@ -6776,6 +6789,13 @@ react-native-screens@~3.20.0:
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
+
+react-native-tab-view@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-3.5.1.tgz#2ad454afc0e186b43ea8b89053f39180d480d48b"
+  integrity sha512-qdrS5t+AEhfuKQyuCXkwHu4IVppkuTvzWWlkSZKrPaSkjjIa32xrsGxt1UW9YDdro2w4AMw5hKn1hFmg/5mvzA==
+  dependencies:
+    use-latest-callback "^0.1.5"
 
 react-native@0.71.8:
   version "0.71.8"


### PR DESCRIPTION
### Description:
This pull request addresses the issue: #25.

### Changes Made:

1. Implemented the "@react-navigation/material-top-tabs" navigator to add tabs for contacts collection and saved searches on the chat page.
2. Added the collection screen and saved searches screen.
3. Included unit tests for the collection and saved searches screens to ensure their functionality.
### Screenshots:


https://github.com/glific/mobile/assets/84832565/1f6007e8-965d-415a-b2f3-5b2a697a8366



### Close Issue
Closes: #25
Please review the changes and let me know if any further modifications or improvements are needed.