### PR TITLE
Adds badge for notification count

### DIFF
--- a/components/HomeHeaderRight.tsx
+++ b/components/HomeHeaderRight.tsx
@@ -34,13 +34,12 @@ const HomeHeaderRight: React.FC = ({ navigation }: any) => {
   const [isFilterVisible, setIsFilterVisible] = useState(false);
   const [notificationCount, setNotificationCount] = useState(0);
 
-  const { loading, error, data } = useQuery(GET_NOTIFICATIONS_COUNT, { variables });
-
-  useEffect(() => {
-    if (data) {
+  useQuery(GET_NOTIFICATIONS_COUNT, {
+    variables,
+    onCompleted: (data) => {
       setNotificationCount(data.countNotifications);
-    }
-  }, [data]);
+    },
+  });
 
   return (
     <View style={styles.mainContainer}>

--- a/components/HomeHeaderRight.tsx
+++ b/components/HomeHeaderRight.tsx
@@ -1,12 +1,21 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View, Pressable } from 'react-native';
 import { Entypo, Ionicons } from '@expo/vector-icons';
 import { COLORS, SCALE, SIZES } from '../constants';
+import { useQuery } from '@apollo/client';
+import { GET_NOTIFICATIONS_COUNT } from '../graphql/queries/Notification';
+import { log } from 'react-native-reanimated';
 
 interface FilterButtonProps {
   label: string;
   count: number;
 }
+
+const variables = {
+  filter: {
+    is_read: false,
+  },
+};
 
 const FilterButton: React.FC<FilterButtonProps> = ({ label, count }) => {
   return (
@@ -23,6 +32,15 @@ const FilterButton: React.FC<FilterButtonProps> = ({ label, count }) => {
 
 const HomeHeaderRight: React.FC = ({ navigation }: any) => {
   const [isFilterVisible, setIsFilterVisible] = useState(false);
+  const [notificationCount, setNotificationCount] = useState(0);
+
+  const { loading, error, data } = useQuery(GET_NOTIFICATIONS_COUNT, { variables });
+
+  useEffect(() => {
+    if (data) {
+      setNotificationCount(data.countNotifications);
+    }
+  }, [data]);
 
   return (
     <View style={styles.mainContainer}>
@@ -32,6 +50,9 @@ const HomeHeaderRight: React.FC = ({ navigation }: any) => {
         android_ripple={{ borderless: true }}
       >
         <Ionicons name="notifications-outline" style={styles.icon} />
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>{notificationCount}</Text>
+        </View>
       </Pressable>
       <Pressable
         onPress={() => setIsFilterVisible(true)}
@@ -59,6 +80,22 @@ const HomeHeaderRight: React.FC = ({ navigation }: any) => {
 export default HomeHeaderRight;
 
 const styles = StyleSheet.create({
+  badge: {
+    alignItems: 'center',
+    backgroundColor: COLORS.red,
+    borderRadius: 10,
+    height: 20,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: -3,
+    top: -3,
+    width: 20,
+  },
+  badgeText: {
+    color: COLORS.white,
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
   filter: {
     alignItems: 'center',
     flexDirection: 'row',

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -21,6 +21,7 @@ export const COLORS = {
   error100: '#f44336',
   white: '#ffffff',
   black: '#212121',
+  red: '#ff0000',
 };
 
 export const SIZES = {

--- a/graphql/queries/Notification.ts
+++ b/graphql/queries/Notification.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export const GET_NOTIFICATIONS_COUNT = gql`
+  query countNotifications($filter: NotificationFilter) {
+    countNotifications(filter: $filter)
+  }
+`;


### PR DESCRIPTION
Description:
This pull request (implements #73) adds a badge to the notification icon that displays the number of notifications obtained from a GraphQL query. The badge is implemented using state management to set the text for the badge dynamically and includes a defined style.

Changes Made:

- Implemented a GraphQL query to fetch the number of notifications
- Utilized state management to dynamically set the text for the badge
- Added styling for the badge

Please review and merge this pull request.

---
https://github.com/glific/mobile/assets/76409986/8158872d-7a29-46fc-aed4-612567ece6de

Initial notification count is set 2 for demonstration purpose.
