### PR TITLE
Mark as Read

### DIFF
--- a/__mocks__/mutations/chats.ts
+++ b/__mocks__/mutations/chats.ts
@@ -1,0 +1,15 @@
+import { MARK_AS_READ } from '../../graphql/mutations/Chat';
+
+export const MARK_AS_READ_MOCK ={
+    request: {
+      query: MARK_AS_READ,
+      variables: {
+        contactId: '1',
+      },
+    },
+    result: {
+      data: {
+        markContactMessagesAsRead: '1',
+      },
+    },
+  };

--- a/__tests__/Chat.test.tsx
+++ b/__tests__/Chat.test.tsx
@@ -4,13 +4,14 @@ import customRender from '../utils/jestRender';
 
 import Chat from '../screens/Chat';
 import { NO_SEARCH_CONTACTS_MOCK } from '../__mocks__/queries/contact';
+import { MARK_AS_READ_MOCK } from '../__mocks__/mutations/chats';
 
 describe('Contact screen', () => {
   test('renders correctly', async () => {
     const navigateMock = jest.fn();
     const { getByTestId, findByText } = customRender(
       <Chat navigation={{ navigate: navigateMock }} />,
-      NO_SEARCH_CONTACTS_MOCK
+      [...NO_SEARCH_CONTACTS_MOCK, MARK_AS_READ_MOCK]
     );
 
     expect(getByTestId('searchInput')).toBeDefined();
@@ -25,12 +26,6 @@ describe('Contact screen', () => {
       expect(findByText('test message')).toBeTruthy();
 
       fireEvent.press(contactCard);
-      // expect(navigateMock).toHaveBeenCalledWith('ChatScreen', {
-      //   id: '17',
-      //   displayName: 'test',
-      //   conversationType: 'contact',
-      //   lastMessageAt: 'test message',
-      // });
     });
   });
 

--- a/components/ContactCard.tsx
+++ b/components/ContactCard.tsx
@@ -45,9 +45,8 @@ const Contact: React.FC<ContactProps> = ({ id, name, lastMessageAt, lastMessage,
   const client = useApolloClient();
   const [markAsRead] = useMutation(MARK_AS_READ, {
     onCompleted: (data) => {
-      console.log(data);
       if (data.markContactMessagesAsRead) {
-        // updateContactCache(client, id);
+        updateContactCache(client, id);
       }
     },
   });
@@ -63,8 +62,7 @@ const Contact: React.FC<ContactProps> = ({ id, name, lastMessageAt, lastMessage,
           conversationType: 'contact',
           lastMessageAt: lastMessageAt,
         });
-      }
-      }
+      }}
       style={styles.item}
       android_ripple={{ color: COLORS.primary10 }}
     >
@@ -88,7 +86,7 @@ const Contact: React.FC<ContactProps> = ({ id, name, lastMessageAt, lastMessage,
           </Text>
         </View>
       </View>
-    </Pressable >
+    </Pressable>
   );
 };
 

--- a/components/ContactCard.tsx
+++ b/components/ContactCard.tsx
@@ -22,13 +22,10 @@ const updateContactCache = (client: any, id: any) => {
     fragment: CONTACT_FRAGMENT,
   });
   if (contact) {
-    const contactCopy = JSON.parse(JSON.stringify(contact));
-
-    contactCopy.isOrgRead = true;
     client.writeFragment({
       id: `Contact:${id}`,
       fragment: CONTACT_FRAGMENT,
-      data: contactCopy,
+      data: { ...contact, isOrgRead: true },
     });
   }
 

--- a/graphql/mutations/Chat.ts
+++ b/graphql/mutations/Chat.ts
@@ -44,3 +44,15 @@ export const CLEAR_MESSAGES = gql`
     }
   }
 `;
+
+export const CONTACT_FRAGMENT = gql`
+  fragment isOrgRead on Contact {
+    isOrgRead
+  }
+`;
+
+export const MARK_AS_READ = gql`
+  mutation markContactMessagesAsRead($contactId: Gid!) {
+    markContactMessagesAsRead(contactId: $contactId)
+  }
+`;


### PR DESCRIPTION
## Implements mark as read after clicking a contact with new message
This PR implements the mark as read feature in the Chat screen using the `markContactMessagesAsRead` mutation when the contact card is clicked. This changes the style for the contact card.

### Changes Made
- Adds `MARK_AD_READ` mutation for marking the message as read when corresponding contact card is clicked in chat screen.
- Adds mocks for the new mutations
- Fixes tests

### Issues
This implements #128 

### Reviewers
@mdshamoon & @ajaman190 , Please review


https://github.com/glific/mobile/assets/76409986/1987bb35-a685-4f0a-8a73-626b9b9906eb



---